### PR TITLE
Display start date, end date, and number of sections (weeks) on "Course Info" tab of instructor dashboard.

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -39,6 +39,7 @@ from course_modes.models import CourseMode, CourseModesArchive
 from student.roles import CourseFinanceAdminRole, CourseSalesAdminRole
 from certificates.models import CertificateGenerationConfiguration
 from certificates import api as certs_api
+from util.date_utils import get_default_time_display
 
 from class_dashboard.dashboard_data import get_section_display_name, get_array_section_has_problem
 from .tools import get_units_with_due_date, title_or_url, bulk_email_is_enabled_for_course
@@ -334,6 +335,9 @@ def _section_course_info(course, access):
         'course_display_name': course.display_name,
         'has_started': course.has_started(),
         'has_ended': course.has_ended(),
+        'start_date': get_default_time_display(course.start),
+        'end_date': get_default_time_display(course.end),
+        'num_sections': len(course.children),
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': unicode(course_key)}),
     }
 

--- a/lms/templates/instructor/instructor_dashboard_2/course_info.html
+++ b/lms/templates/instructor/instructor_dashboard_2/course_info.html
@@ -73,6 +73,22 @@
       <b>${_("No")}</b>
       %endif
     </li>
+
+    <li class="field text is-not-editable" id="field-course-start-date">
+      <label for="course-start-date">${_("Course Start Date:")}</label>
+      <b>${ section_data['start_date'] }</b>
+    </li>
+
+    <li class="field text is-not-editable" id="field-course-end-date">
+      <label for="course-end-date">${_("Course End Date:")}</label>
+      <b>${ section_data['end_date'] }</b>
+    </li>
+
+    <li class="field text is-not-editable" id="field-course-num-sections">
+      <label for="course-num-sections">${_("Number of sections:")}</label>
+      <b>${ section_data['num_sections'] }</b>
+    </li>
+
     <li class="field text is-not-editable" id="field-grade-cutoffs">
       <label for="start-date">${_("Grade Cutoffs:")}</label>
       <b>${ section_data['grade_cutoffs'] }</b>


### PR DESCRIPTION
This PR adds the following information to the "Course Info" tab of the new instructor dashboard:

- Course start date
- Course end date
- Number of sections

**Affected components**: LMS

**Affected users**: staff/instructors

### Screenshots

![Course Info tab with start date, end date, number of sections](https://cloud.githubusercontent.com/assets/961441/9068001/071572e6-3ae1-11e5-9f99-1ec9ffb568e2.png)

### Testing

1.  Go to the [sandbox](http://sandbox.opencraft.com/) and sign in as `staff@example.com`.

2.  Navigate to the [instructor dashboard](http://sandbox.opencraft.com/courses/OpenCraft/DECT101/2015/instructor) of the DECT101 course. Verify that you are looking at the "Course Info" tab.

3. You will find the information described above under "Basic Course Information".

### Partner Information

Not an edX partner - 3rd party-hosted open edX instance